### PR TITLE
FEAT: MON-28: Create MP endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "jwks-rsa": "^3.1.0",
+        "mercadopago": "^2.1.0",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "pg": "^8.13.1",
@@ -6335,6 +6336,15 @@
       },
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/mercadopago": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mercadopago/-/mercadopago-2.1.0.tgz",
+      "integrity": "sha512-3Kx5AAPWEPnO9aSHhbAYPIYpKjM2QtyUJ/mEuBA0AeD19Mt8KViAN3vKqaZCxtEFgeiw+388m0HeBTOEGxU/7w==",
+      "dependencies": {
+        "node-fetch": "^2.6.12",
+        "uuid": "^9.0.0"
       }
     },
     "node_modules/merge-descriptors": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "jwks-rsa": "^3.1.0",
+    "mercadopago": "^2.1.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.13.1",

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -15,8 +15,8 @@ describe('AppController', () => {
   });
 
   describe('root', () => {
-    it('should return "Hello World!"', () => {
-      expect(appController.getHello()).toBe('Hello World!');
+    it('should be defined', () => {
+      expect(appController).toBeDefined();
     });
   });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,7 @@
+export enum backUrlEnum {
+  SUCCESS = 'home',
+  FAILURE = 'profile',
+  PENDING = 'friends',
+}
+
+export const APP_SCHEMA = 'acme';

--- a/src/gifts-payments/dto/preference.dto.ts
+++ b/src/gifts-payments/dto/preference.dto.ts
@@ -1,0 +1,58 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class PreferenceDto {
+  @ApiProperty({
+    description: 'Amount',
+    type: 'number',
+    minLength: 1,
+    required: true,
+  })
+  @IsNotEmpty()
+  @IsNumber()
+  amount: number;
+
+  @ApiProperty({
+    description: 'Gift Id',
+    type: 'string',
+    minLength: 1,
+    required: true,
+  })
+  @IsNotEmpty()
+  @IsString()
+  giftId: string;
+
+  @ApiProperty({
+    description: 'Product Name',
+    type: 'string',
+    minLength: 1,
+    required: true,
+  })
+  @IsNotEmpty()
+  @IsString()
+  productName: string;
+
+  @ApiProperty({
+    description: 'User Id',
+    type: 'string',
+    minLength: 1,
+    required: true,
+  })
+  @IsNotEmpty()
+  @IsString()
+  userId: string;
+
+  @ApiProperty({
+    description: 'Message',
+    type: 'string',
+    minLength: 1,
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  message?: string;
+
+  constructor(partial: Partial<PreferenceDto> = {}) {
+    Object.assign(this, partial);
+  }
+}

--- a/src/gifts-payments/entities/gifts-payment.ts
+++ b/src/gifts-payments/entities/gifts-payment.ts
@@ -17,7 +17,7 @@ export class GiftsPayment {
   gift: Gift;
 
   @ManyToOne(() => User, (user) => user.giftPayments, { onDelete: 'RESTRICT' })
-  user: User;
+  user: Partial<User>;
 
   @Column('decimal')
   amount: number;

--- a/src/gifts-payments/gifts-payments.controller.spec.ts
+++ b/src/gifts-payments/gifts-payments.controller.spec.ts
@@ -1,0 +1,321 @@
+const mockGiftsPaymentsService = {
+  findAll: jest.fn(),
+  createPreference: jest.fn(),
+  savePaymentData: jest.fn(),
+  create: jest.fn(),
+};
+
+const mockGiftsPaymentsRepository = {
+  find: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+};
+
+const mockUsersRepository = {
+  findOne: jest.fn(),
+};
+
+const mockRes = {
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn().mockImplementation((data) => data),
+  sendStatus: jest.fn(),
+  send: jest.fn(),
+  jsonp: jest.fn(),
+} as unknown as Response;
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { GiftsPaymentsController } from './gifts-payments.controller';
+import { GiftsPaymentsService } from './gifts-payments.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { GiftsPayment } from './entities/gifts-payment';
+import { User } from '../users/entities/user';
+import { Response } from 'express';
+
+describe('GiftsPaymentsController', () => {
+  let controller: GiftsPaymentsController;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [GiftsPaymentsController],
+      providers: [
+        GiftsPaymentsService,
+        {
+          provide: GiftsPaymentsService,
+          useValue: mockGiftsPaymentsService,
+        },
+        {
+          provide: getRepositoryToken(GiftsPayment),
+          useValue: mockGiftsPaymentsRepository,
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: mockUsersRepository,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<GiftsPaymentsController>(GiftsPaymentsController);
+  });
+
+  describe('findAll', () => {
+    let response;
+
+    describe('when GiftsPaymentsService.findAll success', () => {
+      beforeEach(async () => {
+        mockGiftsPaymentsService.findAll.mockResolvedValueOnce([{ id: 1 }]);
+        response = await controller.findAll();
+      });
+
+      test('should call GiftsPaymentsService.findAll', () => {
+        expect(mockGiftsPaymentsService.findAll).toHaveBeenCalled();
+      });
+
+      test('should return all gifts payments', () => {
+        expect(response).toEqual([{ id: 1 }]);
+      });
+    });
+
+    describe('when GiftsPaymentsService.findAll rejects', () => {
+      beforeEach(async () => {
+        mockGiftsPaymentsService.findAll.mockRejectedValueOnce(new Error());
+        try {
+          response = await controller.findAll();
+        } catch (error) {
+          response = error;
+        }
+      });
+
+      test('should call GiftsPaymentsService.findAll', () => {
+        expect(mockGiftsPaymentsService.findAll).toHaveBeenCalled();
+      });
+
+      test('should return an instance of Error', () => {
+        expect(response).toBeInstanceOf(Error);
+      });
+    });
+  });
+
+  describe('createPreference', () => {
+    let preferenceDto;
+    let response;
+
+    beforeAll(() => {
+      preferenceDto = { id: 1 };
+    });
+
+    describe('when GiftsPaymentsService.createPreference success', () => {
+      beforeEach(async () => {
+        mockGiftsPaymentsService.createPreference.mockResolvedValueOnce({
+          id: 1,
+          items: [{ productName: 'productName', amount: 123 }],
+        });
+        response = await controller.createPreference(preferenceDto);
+      });
+
+      test('should call GiftsPaymentsService.createPreference with preferenceDto', () => {
+        expect(mockGiftsPaymentsService.createPreference).toHaveBeenCalledWith(
+          preferenceDto,
+        );
+      });
+
+      test('should return a preference', () => {
+        expect(response).toEqual({
+          id: 1,
+          items: [{ productName: 'productName', amount: 123 }],
+        });
+      });
+    });
+
+    describe('when GiftsPaymentsService.createPreference rejects', () => {
+      beforeEach(async () => {
+        mockGiftsPaymentsService.createPreference.mockRejectedValueOnce(
+          new Error(),
+        );
+        try {
+          response = await controller.createPreference(preferenceDto);
+        } catch (error) {
+          response = error;
+        }
+      });
+
+      test('should call GiftsPaymentsService.createPreference with preferenceDto', () => {
+        expect(mockGiftsPaymentsService.createPreference).toHaveBeenCalledWith(
+          preferenceDto,
+        );
+      });
+
+      test('should return an instance of Error', () => {
+        expect(response).toBeInstanceOf(Error);
+      });
+    });
+  });
+
+  describe('save', () => {
+    let body;
+    let response;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    describe('when GiftsPaymentsService.savePaymentData success', () => {
+      describe('when there is payment Id', () => {
+        beforeAll(() => {
+          body = {
+            data: {
+              id: 'id',
+            },
+          };
+        });
+
+        beforeEach(async () => {
+          mockGiftsPaymentsService.savePaymentData.mockResolvedValueOnce(
+            undefined,
+          );
+          response = await controller.save(body, mockRes);
+        });
+
+        test('should call GiftsPaymentsService.savePaymentData with id', () => {
+          expect(mockGiftsPaymentsService.savePaymentData).toHaveBeenCalledWith(
+            body.data.id,
+          );
+        });
+
+        test('should return an object with success equal true', () => {
+          expect(response).toEqual({ success: true });
+        });
+      });
+
+      describe('when there is no payment Id', () => {
+        beforeAll(() => {
+          body = {
+            data: {},
+          };
+        });
+
+        beforeEach(async () => {
+          try {
+            response = await controller.save(body, mockRes);
+          } catch (error) {
+            response = error;
+          }
+        });
+
+        test('should not call GiftsPaymentsService.savePaymentData', () => {
+          expect(
+            mockGiftsPaymentsService.savePaymentData,
+          ).not.toHaveBeenCalled();
+        });
+
+        test('should return an object with success equal false', () => {
+          expect(response).toEqual({ success: false });
+        });
+      });
+    });
+
+    describe('when GiftsPaymentsService.savePaymentData rejects', () => {
+      beforeAll(() => {
+        body = {
+          data: {
+            id: 'id',
+          },
+        };
+      });
+
+      beforeEach(async () => {
+        mockGiftsPaymentsService.savePaymentData.mockRejectedValueOnce(
+          new Error(),
+        );
+        try {
+          response = await controller.save(body, mockRes);
+        } catch (error) {
+          response = error;
+        }
+      });
+
+      test('should call GiftsPaymentsService.savePaymentData with id', () => {
+        expect(mockGiftsPaymentsService.savePaymentData).toHaveBeenCalledWith(
+          body.data.id,
+        );
+      });
+
+      test('should return an object with success equal false', () => {
+        expect(response).toEqual({ success: false });
+      });
+    });
+  });
+
+  describe('create', () => {
+    let response;
+    let body;
+    let req;
+
+    beforeAll(() => {
+      body = {
+        amount: 100,
+        currency: 'USD',
+        source: 'card',
+        gift: 1,
+      };
+
+      req = {
+        user: { sub: 'user-id' },
+      };
+    });
+
+    describe('when GiftsPaymentsService.create success', () => {
+      beforeEach(async () => {
+        mockGiftsPaymentsService.create.mockResolvedValueOnce({
+          user: req.user,
+          ...body,
+        });
+        response = await controller.create(req, body);
+      });
+
+      test('should call GiftsPaymentsService.create with data', () => {
+        expect(mockGiftsPaymentsService.create).toHaveBeenCalledWith({
+          amount: 100,
+          currency: 'USD',
+          gift: 1,
+          source: 'card',
+          user: 'user-id',
+        });
+      });
+
+      test('should return data', () => {
+        expect(response).toEqual({
+          amount: 100,
+          currency: 'USD',
+          gift: 1,
+          source: 'card',
+          user: 'user-id',
+        });
+      });
+    });
+
+    describe('when GiftsPaymentsService.create rejects', () => {
+      beforeEach(async () => {
+        mockGiftsPaymentsService.create.mockRejectedValueOnce(new Error());
+        try {
+          response = await controller.create(req, body);
+        } catch (error) {
+          response = error;
+        }
+      });
+
+      test('should call GiftsPaymentsService.create with data', () => {
+        expect(mockGiftsPaymentsService.create).toHaveBeenCalledWith({
+          amount: 100,
+          currency: 'USD',
+          gift: 1,
+          source: 'card',
+          user: 'user-id',
+        });
+      });
+
+      test('should return an instance of Error', () => {
+        expect(response).toBeInstanceOf(Error);
+      });
+    });
+  });
+});

--- a/src/gifts-payments/gifts-payments.controller.ts
+++ b/src/gifts-payments/gifts-payments.controller.ts
@@ -1,19 +1,66 @@
-import { Controller, Get, Post, Body, UseGuards, Req, Logger } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  UseGuards,
+  Req,
+  Res,
+  HttpStatus,
+} from '@nestjs/common';
 import { GiftsPaymentsService } from './gifts-payments.service';
 import { GiftsPayment } from './entities/gifts-payment';
-import { ApiBearerAuth, ApiBody, ApiResponse } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiOperation } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
+import { Response } from 'express';
+import { PreferenceDto } from './dto/preference.dto';
 
 @Controller('gifts-payments')
 export class GiftsPaymentsController {
   constructor(private readonly giftsPaymentsService: GiftsPaymentsService) {}
 
   @Get()
+  @ApiOperation({
+    description: 'Get all payments',
+  })
   findAll() {
     return this.giftsPaymentsService.findAll();
   }
 
-  @Post()
+  @Post('create-preference')
+  @ApiBody({
+    description: 'Create a preference to send to Mercado Pago.',
+    type: PreferenceDto,
+  })
+  createPreference(@Body() preferenceDto: PreferenceDto) {
+    return this.giftsPaymentsService.createPreference(preferenceDto);
+  }
+
+  @Post('save')
+  @ApiBody({
+    description:
+      'Saves the payment information from Mercado Pago webhook. The body is the payment object returned by Mercado Pago.',
+  })
+  async save(@Body() body: any, @Res() res: Response) {
+    try {
+      const paymentId = body?.data?.id;
+
+      if (!paymentId) {
+        return res.status(HttpStatus.NOT_FOUND).json({ success: false });
+      }
+
+      await this.giftsPaymentsService.savePaymentData(body?.data?.id);
+
+      return res.status(HttpStatus.OK).json({ success: true });
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (error) {
+      return res
+        .status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .json({ success: false });
+    }
+  }
+
+  @Post('create')
   @ApiBearerAuth('JWT')
   @UseGuards(AuthGuard('jwt'))
   @ApiBody({

--- a/src/gifts-payments/gifts-payments.module.ts
+++ b/src/gifts-payments/gifts-payments.module.ts
@@ -9,7 +9,7 @@ import { User } from 'src/users/entities/user';
   imports: [
     TypeOrmModule.forFeature([GiftsPayment]),
     TypeOrmModule.forFeature([User]),
-  ], // Register the entity here
+  ],
   providers: [GiftsPaymentsService],
   controllers: [GiftsPaymentsController],
 })

--- a/src/gifts-payments/gifts-payments.service.spec.ts
+++ b/src/gifts-payments/gifts-payments.service.spec.ts
@@ -1,0 +1,408 @@
+const mockPreferenceBuilder = jest.fn();
+const mockGetPaymentInfo = jest.fn();
+jest.mock('./helpers/payments.helper', () => ({
+  preferenceBuilder: mockPreferenceBuilder,
+  getPaymentInfo: mockGetPaymentInfo,
+}));
+
+const mockGiftsPaymentsRepository = {
+  find: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+};
+
+const mockUsersRepository = {
+  findOne: jest.fn(),
+};
+
+const mockPreference = {
+  create: jest.fn(),
+};
+const mockPayment = {
+  get: jest.fn(),
+};
+const mockMercadoPagoConfig = {};
+jest.mock('mercadopago', () => ({
+  MercadoPagoConfig: jest.fn().mockImplementation(() => mockMercadoPagoConfig),
+  Preference: jest.fn().mockImplementation(() => mockPreference),
+  Payment: jest.fn().mockImplementation(() => mockPayment),
+}));
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { GiftsPaymentsService } from './gifts-payments.service';
+import { GiftsPayment } from './entities/gifts-payment';
+import { User } from '../users/entities/user';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+describe('GiftsPaymentsService', () => {
+  let service: GiftsPaymentsService;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GiftsPaymentsService,
+        {
+          provide: getRepositoryToken(GiftsPayment),
+          useValue: mockGiftsPaymentsRepository,
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: mockUsersRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<GiftsPaymentsService>(GiftsPaymentsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findAll', () => {
+    let response;
+    const mockData = [
+      {
+        id: 1,
+        amount: 100,
+        currency: 'USD',
+        source: 'Test',
+        createdAt: '2024-12-14T03:00:00.000Z',
+        user: { id: 1, name: 'Test User' },
+        gift: { id: 1, name: 'Test Gift' },
+      },
+    ];
+
+    describe('when GiftsPaymentsRepository.find success', () => {
+      beforeEach(async () => {
+        mockGiftsPaymentsRepository.find.mockResolvedValueOnce(mockData);
+        response = await service.findAll();
+      });
+
+      test('should call GiftsPaymentsRepository.find', () => {
+        expect(mockGiftsPaymentsRepository.find).toHaveBeenCalled();
+      });
+
+      test('should return an array of gifts payments', () => {
+        expect(response).toEqual(mockData);
+      });
+    });
+
+    describe('when GiftsPaymentsRepository.find rejects', () => {
+      beforeEach(async () => {
+        mockGiftsPaymentsRepository.find.mockRejectedValueOnce(new Error());
+        try {
+          response = await service.findAll();
+        } catch (error) {
+          response = error;
+        }
+      });
+
+      test('should call GiftsPaymentsRepository.find', () => {
+        expect(mockGiftsPaymentsRepository.find).toHaveBeenCalled();
+      });
+
+      test('should return an instance of Error', () => {
+        expect(response).toBeInstanceOf(Error);
+      });
+    });
+  });
+
+  describe('createPreference', () => {
+    let mockPreferenceDto;
+    let mockPreferenceData;
+    let response;
+
+    beforeAll(() => {
+      mockPreferenceDto = {
+        amount: 123,
+        giftId: 'giftId',
+        productName: 'productName',
+        userId: 'userId',
+        message: 'message',
+      };
+      mockPreferenceData = {
+        body: {
+          items: [
+            {
+              id: 'id',
+              unit_price: '123',
+              quantity: 1,
+              title: 'productName',
+            },
+          ],
+          metadata: {
+            message: 'message',
+            user_id: 'userId',
+          },
+          operation_type: 'regular_payment',
+          back_urls: {
+            success: 'success',
+            failure: 'failure',
+            pending: 'pending',
+          },
+          auto_return: 'approved',
+          notification_url: 'appHostUrl/gifts-payments/payment-data',
+        },
+      };
+    });
+
+    describe('when MercadoPago Preference success', () => {
+      beforeEach(async () => {
+        mockPreferenceBuilder.mockReturnValueOnce(mockPreferenceData);
+        mockPreference.create.mockResolvedValueOnce(mockPreferenceData);
+        response = await service.createPreference(mockPreferenceDto);
+      });
+
+      test('should call preferenceBuilder with preferenceDto and APP_HOST_URL', () => {
+        expect(mockPreferenceBuilder).toHaveBeenCalledWith(
+          mockPreferenceDto,
+          undefined,
+        );
+      });
+
+      test('should call Preference.create with preferenceData', () => {
+        expect(mockPreference.create).toHaveBeenCalledTimes(1);
+        expect(mockPreference.create).toHaveBeenCalledWith(mockPreferenceData);
+      });
+
+      test('should return created preference from Mercado Pago', () => {
+        expect(response).toEqual(mockPreferenceData);
+      });
+    });
+
+    describe('when MercadoPago Preference rejects', () => {
+      beforeEach(async () => {
+        mockPreferenceBuilder.mockReturnValueOnce(mockPreferenceData);
+        mockPreference.create.mockRejectedValueOnce(new Error());
+        try {
+          response = await service.createPreference(mockPreferenceDto);
+        } catch (error) {
+          response = error;
+        }
+      });
+
+      test('should call preferenceBuilder with preferenceDto and APP_HOST_URL', () => {
+        expect(mockPreferenceBuilder).toHaveBeenCalledWith(
+          mockPreferenceDto,
+          undefined,
+        );
+      });
+
+      test('should call Preference.create with preferenceData', () => {
+        expect(mockPreference.create).toHaveBeenCalledTimes(1);
+        expect(mockPreference.create).toHaveBeenCalledWith(mockPreferenceData);
+      });
+
+      test('should return an instance of Error', () => {
+        expect(response).toBeInstanceOf(Error);
+      });
+    });
+  });
+
+  describe('create', () => {
+    let data;
+    let updatedData;
+    let mockUser;
+    let response;
+
+    beforeAll(() => {
+      data = {
+        amount: 100,
+        user: { userId: 'userId' },
+      };
+      mockUser = {
+        userId: 'userId',
+        name: 'Test User',
+      };
+      updatedData = {
+        amount: 100,
+        user: { userId: 'userId', name: 'Test User' },
+      };
+    });
+
+    describe('when UsersRepository.find finds user', () => {
+      beforeEach(async () => {
+        mockUsersRepository.findOne.mockResolvedValueOnce(mockUser);
+        mockGiftsPaymentsRepository.create.mockResolvedValueOnce(updatedData);
+        mockGiftsPaymentsRepository.save.mockResolvedValueOnce(updatedData);
+        response = await service.create(data);
+      });
+
+      test('should call UsersRepository.findOne with query', () => {
+        expect(mockUsersRepository.findOne).toHaveBeenCalledWith({
+          where: { userId: data.user.userId },
+        });
+      });
+
+      test('should call GiftsPaymentsRepository.create with updated data', () => {
+        expect(mockGiftsPaymentsRepository.create).toHaveBeenCalledWith(
+          updatedData,
+        );
+      });
+
+      test('should call GiftsPaymentsRepository.save with updated data', () => {
+        expect(mockGiftsPaymentsRepository.create).toHaveBeenCalledWith(
+          updatedData,
+        );
+      });
+
+      test('should return updated data', () => {
+        expect(response).toEqual(updatedData);
+      });
+    });
+
+    describe('when UsersRepository.find does not find user', () => {
+      beforeEach(async () => {
+        mockUsersRepository.findOne.mockResolvedValueOnce(undefined);
+        try {
+          response = await service.create(data);
+        } catch (error) {
+          response = error;
+        }
+      });
+
+      test('should call UsersRepository.findOne with query', () => {
+        expect(mockUsersRepository.findOne).toHaveBeenCalledWith({
+          where: { userId: data.user.userId },
+        });
+      });
+
+      test('should not call GiftsPaymentsRepository.create', () => {
+        expect(mockGiftsPaymentsRepository.create).not.toHaveBeenCalled();
+      });
+
+      test('should not call GiftsPaymentsRepository.save', () => {
+        expect(mockGiftsPaymentsRepository.create).not.toHaveBeenCalled();
+      });
+
+      test('should return an instance of Error', () => {
+        expect(response).toBeInstanceOf(Error);
+      });
+    });
+  });
+
+  describe('savePaymentData', () => {
+    let mockPaymentId;
+    let mockPaymentResponse;
+    let mockPaymentInfo;
+    let mockCreate;
+    let response;
+
+    beforeAll(() => {
+      mockCreate = jest.spyOn(service, 'create');
+      mockPaymentId = 'paymentId';
+      mockPaymentInfo = {
+        amount: 100,
+        user: { userId: 'test-user-id' },
+      };
+    });
+
+    describe('when Mercado Pago Payment.get success', () => {
+      describe('when payment.status is equal to approved', () => {
+        beforeAll(() => {
+          mockPaymentResponse = {
+            status: 'approved',
+            transaction_amount: 100,
+          };
+        });
+
+        beforeEach(async () => {
+          mockPayment.get.mockResolvedValueOnce(mockPaymentResponse);
+          mockGetPaymentInfo.mockReturnValueOnce(mockPaymentInfo);
+          mockCreate.mockResolvedValueOnce({
+            id: 1,
+            amount: 100,
+            user: { userId: 'test-user-id' },
+          });
+          response = await service.savePaymentData(mockPaymentId);
+        });
+
+        test('should call Mercado Pagon Payment.get with paymentId', () => {
+          expect(mockPayment.get).toHaveBeenCalledWith({ id: mockPaymentId });
+        });
+
+        test('should call getPaymentInfo with payment response', () => {
+          expect(mockGetPaymentInfo).toHaveBeenCalledWith(mockPaymentResponse);
+        });
+
+        test('should call GiftsPaymentsService.create with payment info', () => {
+          expect(mockCreate).toHaveBeenCalledWith(mockPaymentInfo);
+        });
+
+        test('should return undefined', () => {
+          expect(response).toBeUndefined();
+        });
+      });
+
+      describe('when payment.status is different than approved', () => {
+        beforeAll(() => {
+          mockPaymentResponse = {
+            status: 'rejected',
+            transaction_amount: 100,
+          };
+        });
+
+        beforeEach(async () => {
+          mockPayment.get.mockResolvedValueOnce(mockPaymentResponse);
+          mockGetPaymentInfo.mockReturnValueOnce(mockPaymentInfo);
+          mockCreate.mockResolvedValueOnce({
+            id: 1,
+            amount: 100,
+            user: { userId: 'test-user-id' },
+          });
+          response = await service.savePaymentData(mockPaymentId);
+        });
+
+        test('should call Mercado Pagon Payment.get with paymentId', () => {
+          expect(mockPayment.get).toHaveBeenCalledWith({ id: mockPaymentId });
+        });
+
+        test('should not call getPaymentInfo', () => {
+          expect(mockGetPaymentInfo).not.toHaveBeenCalled();
+        });
+
+        test('should not call GiftsPaymentsService.create', () => {
+          expect(mockCreate).not.toHaveBeenCalled();
+        });
+
+        test('should return undefined', () => {
+          expect(response).toBeUndefined();
+        });
+      });
+    });
+
+    describe('when Mercado Pago Payment.get rejects', () => {
+      beforeEach(async () => {
+        mockPayment.get.mockRejectedValueOnce(new Error());
+        mockGetPaymentInfo.mockReturnValueOnce(mockPaymentInfo);
+        mockCreate.mockResolvedValueOnce({
+          id: 1,
+          amount: 100,
+          user: { userId: 'test-user-id' },
+        });
+        try {
+          response = await service.savePaymentData(mockPaymentId);
+        } catch (error) {
+          response = error;
+        }
+      });
+
+      test('should call Mercado Pagon Payment.get with paymentId', () => {
+        expect(mockPayment.get).toHaveBeenCalledWith({ id: mockPaymentId });
+      });
+
+      test('should not call getPaymentInfo', () => {
+        expect(mockGetPaymentInfo).not.toHaveBeenCalled();
+      });
+
+      test('should not call GiftsPaymentsService.create', () => {
+        expect(mockCreate).not.toHaveBeenCalled();
+      });
+
+      test('should return an instance of Error', () => {
+        expect(response).toBeInstanceOf(Error);
+      });
+    });
+  });
+});

--- a/src/gifts-payments/gifts-payments.service.ts
+++ b/src/gifts-payments/gifts-payments.service.ts
@@ -1,31 +1,72 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { GiftsPayment } from './entities/gifts-payment';
-import { UsersService } from 'src/users/users.service';
-import { User } from 'src/users/entities/user';
+// import { User } from 'src/users/entities/user';
+import { User } from '../users/entities/user';
+import { MercadoPagoConfig, Payment, Preference } from 'mercadopago';
+import { getPaymentInfo, preferenceBuilder } from './helpers/payments.helper';
+import { PreferenceDto } from './dto/preference.dto';
 
 @Injectable()
 export class GiftsPaymentsService {
+  private mercadoPago: MercadoPagoConfig;
+  private readonly logger = new Logger(GiftsPaymentsService.name);
+
   constructor(
     @InjectRepository(GiftsPayment)
     private giftsPaymentsRepository: Repository<GiftsPayment>,
     @InjectRepository(User)
     private usersRepository: Repository<User>,
-  ) {}
-
-  findAll() {
-    return this.giftsPaymentsRepository.find();
+  ) {
+    this.mercadoPago = new MercadoPagoConfig({
+      accessToken: process.env.MP_ACCESS_TOKEN,
+    });
   }
 
-  async create(data: Partial<GiftsPayment>) {
+  findAll() {
+    return this.giftsPaymentsRepository.find({ relations: ['user', 'gift'] });
+  }
+
+  async createPreference(preferenceDto: PreferenceDto) {
+    const preferenceData = preferenceBuilder(
+      preferenceDto,
+      process.env.APP_HOST_URL,
+    );
+
+    const preference = await new Preference(this.mercadoPago).create(
+      preferenceData,
+    );
+
+    return preference;
+  }
+
+  async savePaymentData(paymentId: string) {
+    const payment = await new Payment(this.mercadoPago).get({
+      id: paymentId,
+    });
+
+    if (payment?.status === 'approved') {
+      const paymentInfo = getPaymentInfo(payment);
+
+      this.logger.log('Saving payment info in database');
+      await this.create(paymentInfo);
+      console.log('paymentInfo', paymentInfo);
+      return undefined;
+    }
+
+    return undefined;
+  }
+
+  async create(data: any) {
     const user = await this.usersRepository.findOne({
-      where: { userId: data.user.toString() },
+      where: { userId: data.user.userId },
     });
 
     if (!user) throw new NotFoundException('User not found');
 
     data.user = user;
+
     const giftPayment = this.giftsPaymentsRepository.create(data);
     return this.giftsPaymentsRepository.save(giftPayment);
   }

--- a/src/gifts-payments/helpers/payments.helper.spec.ts
+++ b/src/gifts-payments/helpers/payments.helper.spec.ts
@@ -1,0 +1,142 @@
+const APP_SCHEMA = 'APP_SCHEMA';
+const backUrlEnum = {
+  SUCCESS: 'SUCCESS',
+  FAILURE: 'FAILURE',
+  PENDING: 'PENDING',
+};
+jest.mock('../../constants', () => ({
+  APP_SCHEMA,
+  backUrlEnum,
+}));
+
+import * as paymentsHelper from './payments.helper';
+
+describe('Payments Helper', () => {
+  describe('preferenceBuilder', () => {
+    let appHostUrl;
+    let preferenceDraft;
+    let result;
+
+    beforeAll(() => {
+      appHostUrl = 'appHostUrl';
+      preferenceDraft = {
+        amount: 123,
+        giftId: 'giftId',
+        productName: 'productName',
+        userId: 'userId',
+        message: 'message',
+      };
+    });
+
+    beforeEach(() => {
+      result = paymentsHelper.preferenceBuilder(preferenceDraft, appHostUrl);
+    });
+
+    test('should return a preference object', () => {
+      expect(result).toEqual({
+        body: {
+          auto_return: 'approved',
+          back_urls: {
+            failure: 'APP_SCHEMA://FAILURE',
+            pending: 'APP_SCHEMA://PENDING',
+            success: 'APP_SCHEMA://SUCCESS',
+          },
+          items: [
+            {
+              id: 'giftId',
+              quantity: 1,
+              title: 'productName',
+              unit_price: 123,
+            },
+          ],
+          metadata: { message: 'message', user_id: 'userId' },
+          notification_url: 'appHostUrl/gifts-payments/payment-data',
+          operation_type: 'regular_payment',
+        },
+      });
+    });
+  });
+
+  describe('getGiftInfo', () => {
+    let payment;
+    let result;
+
+    beforeAll(() => {
+      payment = {
+        additional_info: {
+          items: [
+            {
+              id: 'id',
+              title: 'title',
+              unit_price: 123,
+            },
+          ],
+        },
+        currency_id: 'ARS',
+        metadata: {
+          message: 'message',
+        },
+      };
+    });
+
+    beforeEach(() => {
+      result = paymentsHelper.getGiftInfo(payment);
+    });
+
+    test('should return a gift info object', () => {
+      expect(result).toEqual({
+        currency: 'ARS',
+        description: 'message',
+        id: 'id',
+        price: 123,
+        title: 'title',
+      });
+    });
+  });
+
+  describe('getPaymentInfo', () => {
+    let mockGetGiftInfo;
+    let payment;
+    let result;
+
+    beforeAll(() => {
+      mockGetGiftInfo = jest.spyOn(paymentsHelper, 'getGiftInfo');
+      payment = {
+        transaction_amount: 123,
+        currency_id: 'ARS',
+        date_created: '2024-12-14T03:00:00.000Z',
+        metadata: {
+          user_id: 'userId',
+        },
+      };
+    });
+
+    beforeEach(() => {
+      mockGetGiftInfo.mockReturnValueOnce({
+        currency: 'ARS',
+        description: 'message',
+        id: 'id',
+        price: 123,
+        title: 'title',
+      });
+      result = paymentsHelper.getPaymentInfo(payment);
+    });
+
+    test('should return a payment info object', () => {
+      expect(result).toEqual({
+        amount: 123,
+        createdAt: new Date('2024-12-14T03:00:00.000Z'),
+        currency: 'ARS',
+        gift: {
+          currency: 'ARS',
+          description: 'message',
+          id: 'id',
+          price: 123,
+          title: 'title',
+        },
+        source: 'Mercado Pago',
+        user: { userId: 'userId' },
+      });
+    });
+  });
+});

--- a/src/gifts-payments/helpers/payments.helper.ts
+++ b/src/gifts-payments/helpers/payments.helper.ts
@@ -1,0 +1,52 @@
+import { APP_SCHEMA, backUrlEnum } from '../../constants';
+import { IPreferenceBody } from '../interfaces/preference.interface';
+
+export const preferenceBuilder = (
+  preferenceDraft: IPreferenceBody,
+  appHostUrl: string,
+) => {
+  return {
+    body: {
+      items: [
+        {
+          id: preferenceDraft.giftId,
+          unit_price: preferenceDraft.amount,
+          quantity: 1,
+          title: preferenceDraft.productName,
+        },
+      ],
+      metadata: {
+        message: preferenceDraft?.message,
+        user_id: preferenceDraft.userId,
+      },
+      operation_type: 'regular_payment',
+      back_urls: {
+        success: `${APP_SCHEMA}://${backUrlEnum.SUCCESS}`,
+        failure: `${APP_SCHEMA}://${backUrlEnum.FAILURE}`,
+        pending: `${APP_SCHEMA}://${backUrlEnum.PENDING}`,
+      },
+      auto_return: 'approved',
+      notification_url: `${appHostUrl}/gifts-payments/save`,
+    },
+  };
+};
+
+export const getGiftInfo = (payment: any) => {
+  const { id, title, unit_price } = payment.additional_info.items[0];
+  return {
+    id,
+    title,
+    currency: payment.currency_id,
+    price: unit_price,
+    description: payment?.metadata?.message,
+  };
+};
+
+export const getPaymentInfo = (payment: any) => ({
+  gift: getGiftInfo(payment),
+  user: { userId: payment.metadata.user_id },
+  amount: payment.transaction_amount,
+  currency: payment.currency_id,
+  source: 'Mercado Pago',
+  createdAt: new Date(payment.date_created),
+});

--- a/src/gifts-payments/interfaces/preference.interface.ts
+++ b/src/gifts-payments/interfaces/preference.interface.ts
@@ -5,38 +5,3 @@ export interface IPreferenceBody {
   userId: string;
   message?: string;
 }
-
-export interface IUser {
-  userId: string;
-  userName?: string;
-  firstName?: string;
-  lastName?: string;
-  email?: string;
-  phone?: string;
-  address?: string;
-  image?: string;
-  birthday?: Date;
-  lastSeen?: Date;
-}
-
-export interface IGift {
-  id: number;
-  title?: string;
-  description?: string;
-  link?: string;
-  price?: number;
-  currency?: string;
-  endDate?: Date;
-  image?: string;
-  user?: IUser;
-  createdAt?: Date;
-}
-
-export interface IPaymentInfo {
-  gift: IGift;
-  user: IUser;
-  amount: number;
-  currency: string;
-  source: string;
-  createdAt: Date;
-}

--- a/src/gifts-payments/interfaces/preference.interface.ts
+++ b/src/gifts-payments/interfaces/preference.interface.ts
@@ -1,0 +1,42 @@
+export interface IPreferenceBody {
+  amount: number;
+  giftId: string;
+  productName: string;
+  userId: string;
+  message?: string;
+}
+
+export interface IUser {
+  userId: string;
+  userName?: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  phone?: string;
+  address?: string;
+  image?: string;
+  birthday?: Date;
+  lastSeen?: Date;
+}
+
+export interface IGift {
+  id: number;
+  title?: string;
+  description?: string;
+  link?: string;
+  price?: number;
+  currency?: string;
+  endDate?: Date;
+  image?: string;
+  user?: IUser;
+  createdAt?: Date;
+}
+
+export interface IPaymentInfo {
+  gift: IGift;
+  user: IUser;
+  amount: number;
+  currency: string;
+  source: string;
+  createdAt: Date;
+}

--- a/src/helpers/validation-errors.helper.spec.ts
+++ b/src/helpers/validation-errors.helper.spec.ts
@@ -1,0 +1,173 @@
+import { BadRequestException, HttpStatus } from '@nestjs/common';
+
+import {
+  flattenValidationErrors,
+  formatValidationErrors,
+} from './validation-errors.helper';
+import * as validationErrorsHelper from './validation-errors.helper';
+
+describe('Validation Errors helper', () => {
+  describe('flattenValidationErrors', () => {
+    let errors;
+    let result;
+
+    beforeAll(() => {
+      errors = [
+        {
+          property: 'shippingAddress',
+          children: [
+            {
+              property: 'phone',
+              children: [],
+              constraints: {
+                customValidation: 'phone should be a valid phone number',
+                isNumberString: 'phone must be a number string',
+              },
+            },
+            {
+              property: 'state',
+              children: [],
+              constraints: {
+                customValidation: 'state invalid state',
+              },
+            },
+            {
+              property: 'promotabilityOptions',
+              children: [
+                {
+                  property: 'sourceCode',
+                  children: [],
+                  constraints: {
+                    isNotEmpty: 'sourceCode should not be empty',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ];
+    });
+
+    beforeEach(() => {
+      result = flattenValidationErrors(errors);
+    });
+
+    test('should return an array of objects containing invalidProperty and messages', () => {
+      expect(result).toEqual([
+        {
+          invalidProperty: 'shippingAddress.phone',
+          messages: [
+            'shippingAddress.phone should be a valid phone number',
+            'shippingAddress.phone must be a number string',
+          ],
+        },
+        {
+          invalidProperty: 'shippingAddress.state',
+          messages: ['shippingAddress.state invalid state'],
+        },
+        {
+          invalidProperty: 'shippingAddress.promotabilityOptions.sourceCode',
+          messages: [
+            'shippingAddress.promotabilityOptions.sourceCode should not be empty',
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe('formatValidationErrors', () => {
+    let errors;
+    let mockFlattenValidationErrors;
+    let result;
+
+    beforeAll(() => {
+      errors = [
+        {
+          property: 'shippingAddress',
+          children: [
+            {
+              property: 'phone',
+              children: [],
+              constraints: {
+                customValidation: 'phone should be a valid phone number',
+                isNumberString: 'phone must be a number string',
+              },
+            },
+            {
+              property: 'state',
+              children: [],
+              constraints: {
+                customValidation: 'state invalid state',
+              },
+            },
+            {
+              property: 'promotabilityOptions',
+              children: [
+                {
+                  property: 'sourceCode',
+                  children: [],
+                  constraints: {
+                    isNotEmpty: 'sourceCode should not be empty',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ];
+    });
+
+    beforeEach(() => {
+      mockFlattenValidationErrors = jest
+        .spyOn(validationErrorsHelper, 'flattenValidationErrors')
+        .mockReturnValueOnce([
+          {
+            invalidProperty: 'shippingAddress.phone',
+            messages: [
+              'shippingAddress.phone should be a valid phone number',
+              'shippingAddress.phone must be a number string',
+            ],
+          },
+          {
+            invalidProperty: 'shippingAddress.state',
+            messages: ['shippingAddress.state invalid state'],
+          },
+          {
+            invalidProperty: 'shippingAddress.promotabilityOptions.sourceCode',
+            messages: [
+              'shippingAddress.promotabilityOptions.sourceCode should not be empty',
+            ],
+          },
+        ]);
+      try {
+        result = formatValidationErrors(errors);
+      } catch (error) {
+        result = error;
+      }
+    });
+
+    test('should call flattenValidationErrors with errors', () => {
+      expect(mockFlattenValidationErrors).toHaveBeenCalledWith(errors);
+    });
+
+    test('should throw a BadRequestException with VALIDATION_ERROR error code, invalidProperties as an array of properties names and message', () => {
+      expect(result).toEqual(
+        new BadRequestException({
+          statusCode: HttpStatus.BAD_REQUEST,
+          code: 'VALIDATION_ERROR',
+          invalidProperties: [
+            'shippingAddress.phone',
+            'shippingAddress.state',
+            'shippingAddress.promotabilityOptions.sourceCode',
+          ],
+          message: [
+            'shippingAddress.phone should be a valid phone number',
+            'shippingAddress.phone must be a number string',
+            'shippingAddress.state invalid state',
+            'shippingAddress.promotabilityOptions.sourceCode should not be empty',
+          ],
+        }),
+      );
+    });
+  });
+});

--- a/src/helpers/validation-errors.helper.ts
+++ b/src/helpers/validation-errors.helper.ts
@@ -1,0 +1,51 @@
+import {
+  BadRequestException,
+  HttpStatus,
+  ValidationError,
+} from '@nestjs/common';
+
+export const flattenValidationErrors = (
+  errors: ValidationError[],
+  parentProperty = '',
+): { invalidProperty: string; messages: string[] }[] => {
+  let response = [];
+
+  errors.forEach((error) => {
+    const currentProperty = parentProperty
+      ? `${parentProperty}.${error.property}`
+      : error.property;
+    const messages = error.constraints
+      ? Object.values(error.constraints).map(
+          (message) =>
+            `${
+              parentProperty ? `${parentProperty}.` : parentProperty
+            }${message}`,
+        )
+      : [];
+
+    if (error.children.length) {
+      response = [
+        ...response,
+        ...flattenValidationErrors(error.children, currentProperty),
+      ];
+    } else {
+      response = [...response, { invalidProperty: currentProperty, messages }];
+    }
+  });
+
+  return response;
+};
+
+export const formatValidationErrors = (
+  errors: ValidationError[],
+): BadRequestException => {
+  const flattenedValidationErrors = flattenValidationErrors(errors);
+  throw new BadRequestException({
+    statusCode: HttpStatus.BAD_REQUEST,
+    code: 'VALIDATION_ERROR',
+    invalidProperties: flattenedValidationErrors.map(
+      ({ invalidProperty }) => invalidProperty,
+    ),
+    message: flattenedValidationErrors.map(({ messages }) => messages).flat(),
+  });
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { AppModule } from './app.module';
 import * as dotenv from 'dotenv';
 import { ValidationPipe } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { formatValidationErrors } from './helpers/validation-errors.helper';
 
 dotenv.config();
 
@@ -12,6 +13,7 @@ async function bootstrap() {
   app.enableCors();
   app.useGlobalPipes(
     new ValidationPipe({
+      exceptionFactory: formatValidationErrors,
       disableErrorMessages: true,
     }),
   );

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -11,7 +11,14 @@ import {
 import { UsersService } from './users.service';
 import { User } from './entities/user';
 import { AuthGuard } from '@nestjs/passport';
-import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiQuery, ApiResponse } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+} from '@nestjs/swagger';
 
 @Controller('users')
 export class UsersController {
@@ -52,7 +59,8 @@ export class UsersController {
   @ApiBearerAuth('JWT')
   @UseGuards(AuthGuard('jwt'))
   @ApiOperation({
-    summary: 'Get friends birthdays grouped by upcoming birthdays. UserId is retrieved from the JWT.',
+    summary:
+      'Get friends birthdays grouped by upcoming birthdays. UserId is retrieved from the JWT.',
     description: 'This endpoint retrieves friends birthdays for a given user.',
   })
   @ApiQuery({
@@ -66,7 +74,8 @@ export class UsersController {
 
   @Get('/friends-calendar/:userId')
   @ApiOperation({
-    summary: 'Get friends birthdays grouped by upcoming birthdays. UserId is required to be passed as a param.',
+    summary:
+      'Get friends birthdays grouped by upcoming birthdays. UserId is required to be passed as a param.',
     description: 'This endpoint retrieves friends birthdays for a given user.',
   })
   @ApiParam({
@@ -79,7 +88,10 @@ export class UsersController {
     type: 'string',
     description: 'The date to get friends birthdays for.',
   })
-  groupByUpcomingBirthdays(@Param('userId') userId: string, @Query('date') date: string) {
+  groupByUpcomingBirthdays(
+    @Param('userId') userId: string,
+    @Query('date') date: string,
+  ) {
     return this.usersService.groupByUpcomingBirthdays(userId, date);
   }
 
@@ -87,5 +99,4 @@ export class UsersController {
   findById(@Param('userId') userId: string) {
     return this.usersService.findById(userId);
   }
-
 }


### PR DESCRIPTION
- Updated giftsPayments resource (controller, module, service).
- Created preference.dto.ts to validate input data.
- Created helpers function to create Mercado Pago's preferences and get the payment data from webhook.
- Created validation-errors.helper.ts to display more descriptive errors when DTOs are executed.
- Updated main.ts.
- Added unit-tests.

payments/create-preference body example:
```
{
   "amount": 1, 
   "giftId": "2", 
   "productName": "Nike Shoes", 
   "userId": "123", 
   "message": "message" 
}
```